### PR TITLE
Add optional video conversion to mp4 or lossless mkv.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,9 @@ src/data/bin
 build
 vis
 *.avi
+*.mkv
 *.mov
+*.mp4
 *.webm
 branch.js
 overlay.png

--- a/Makefile
+++ b/Makefile
@@ -41,5 +41,11 @@ webm:
 	ffmpeg -i game_raw.mov -vf scale=320:288 -sws_flags neighbor -c:v libvpx -crf 20 -b:v 1M -c:a libvorbis game.webm
 
 render:
-	ffmpeg -i game_raw.mov -vf scale=480:432 -sws_flags neighbor -acodec libmp3lame -ac 1 -ab 64000 -ar 22050 -vcodec mpeg4 -flags +mv4+gmc -mbd bits -trellis 2 -b 8000k game.avi
+	ffmpeg -i game_raw.mov -vf scale=480:432 -sws_flags neighbor -c:a libmp3lame -ac 1 -ab 64000 -ar 22050 -vcodec mpeg4 -flags +mv4+gmc -mbd bits -trellis 2 -b 8000k game.avi
+
+mp4:
+	ffmpeg -i game_raw.mov -vf scale=320:288 -sws_flags neighbor -c:v libx264 -crf 20 -c:a aac -ab 96k game.mp4
+
+lossless:
+	ffmpeg -i game_raw.mov -c:v libx264 -preset veryslow -crf 0 -c:a flac -compression_level 12 game_raw.mkv
 


### PR DESCRIPTION
Size and quality of game.mp4 is roughly the same as game.webm,
but the format may currently be supported by more output devices.

Size of game_raw.mkv is roughly one-fifth of game_raw.mov,
yet still twice as big as game.webm, and more expensive to
compute.